### PR TITLE
Solved right-click, droppable.accept only once called

### DIFF
--- a/src/droppable/droppable.js
+++ b/src/droppable/droppable.js
@@ -43,6 +43,8 @@ export default class Droppable {
 
 	offset = null;
 
+	canUse = false;
+
 	constructor(element, options = {}, listeners = {}) {
 		if (element instanceof HTMLElement) {
 			this.element = element;
@@ -182,6 +184,7 @@ export default class Droppable {
 
 	activate(event) {
 		const draggable = DragDropManager.draggable;
+		this.canUse = true;
 
 		addClass(this.element, this.activeClass);
 		if (draggable) {
@@ -198,7 +201,7 @@ export default class Droppable {
 	over(event) {
 		const draggable = DragDropManager.draggable;
 
-		if (draggable && (draggable.currentItem || draggable.element) !== this.element && this.accept(draggable)) {
+		if (draggable && (draggable.currentItem || draggable.element) !== this.element && this.canUse) {
 			addClass(this.element, this.hoverClass);
 			this.isOver = true;
 			this.trigger(
@@ -226,7 +229,7 @@ export default class Droppable {
 					droppable.greedy &&
 					droppable.scope === draggable.scope &&
 					droppable.intersect(draggable, event) &&
-					droppable.accept(draggable)
+					droppable.canUse
 				) {
 					childIntersection = true;
 				}
@@ -236,7 +239,8 @@ export default class Droppable {
 				return null;
 			}
 
-			if (this.accept(draggable)) {
+			if (this.canUse) {
+				this.canUse = false;
 				removeClass(this.element, this.activeClass);
 				removeClass(this.element, this.hoverClass);
 				this.isOver = false;
@@ -257,7 +261,7 @@ export default class Droppable {
 	out(event) {
 		const draggable = DragDropManager.draggable;
 
-		if (draggable && (draggable.currentItem || draggable.element) !== this.element && this.accept(draggable)) {
+		if (draggable && (draggable.currentItem || draggable.element) !== this.element && this.canUse) {
 			removeClass(this.element, this.hoverClass);
 			this.isOver = false;
 			this.trigger(
@@ -271,6 +275,7 @@ export default class Droppable {
 	}
 
 	deactivate(event) {
+		this.canUse = false;
 		const draggable = DragDropManager.draggable;
 
 		removeClass(this.element, this.activeClass);

--- a/src/manager/manager.js
+++ b/src/manager/manager.js
@@ -38,7 +38,11 @@ export class DragDropManager {
 						droppable.activate(event);
 					}
 					droppable.refreshProportions();
+				} else {
+					droppable.deactivate(event);
 				}
+			} else {
+				droppable.deactivate(event);
 			}
 		});
 	};

--- a/src/sensor/mouse-sensor.js
+++ b/src/sensor/mouse-sensor.js
@@ -130,7 +130,7 @@ export default class MouseSensor extends Sensor {
 				})
 			);
 		}
-		document.removeEventListener('contextmenu', preventDefault);
+		document.removeEventListener('contextmenu', preventDefault, true);
 		document.removeEventListener('mousemove', this.onMouseMove);
 		event.preventDefault();
 	};


### PR DESCRIPTION
Solved right-click: #16 
If you do `removeEventListener`, you need to pass same args as you do `addEventListener`.

Solved #15 
- `droppable.accept` function is only for first check in order to `activate the droppable`;
- Deactivate the `useless droppables` and set `canUse` to `false`;
- Added a `canUse` variable in the constructor of each droppable and when it is activated you set it on `true`, it means you can use that specific droppable with the draggable;
